### PR TITLE
Update channel "type" to match updated Discord API

### DIFF
--- a/include/discord/channel.inc
+++ b/include/discord/channel.inc
@@ -1,3 +1,12 @@
+enum
+{
+	GUILD_TEXT = 0,
+	DM,
+	GUILD_VOICE,
+	GROUP_DM,
+	GUILD_CATEGORY
+};
+
 methodmap DiscordChannel < StringMap {
 	public DiscordChannel() {
 		Handle hObj = json_object();
@@ -16,10 +25,6 @@ methodmap DiscordChannel < StringMap {
 	
 	public void GetName(char[] buffer, int maxlength) {
 		JsonObjectGetString(this, "name", buffer, maxlength);
-	}
-	
-	public void GetType(char[] buffer, int maxlength) {
-		JsonObjectGetString(this, "type", buffer, maxlength);
 	}
 	
 	property int Position {
@@ -46,6 +51,12 @@ methodmap DiscordChannel < StringMap {
 		json_object_set_new(this, "last_message_id", json_string(id));
 	}
 	
+	property int Type {
+		public get() {
+			return JsonObjectGetInt(this, "type");
+		}
+	}
+	
 	property int Bitrate {
 		public get() {
 			return JsonObjectGetInt(this, "bitrate");
@@ -60,10 +71,7 @@ methodmap DiscordChannel < StringMap {
 	
 	property bool IsText {
 		public get() {
-			char type[8];
-			this.GetType(type, sizeof(type));
-			if(StrEqual(type, "text", false)) return true;
-			return false;
+			return this.Type == GUILD_TEXT;
 		}
 	}
 }


### PR DESCRIPTION
"type" is now an int/enum in the API rather than a string.

Credits to PaxPlay for this, it was a part of the PR he had open, but seems like that won't be getting merged so I made a PR for this specific change.