### PR TITLE
Add 2 methods to includes

### DIFF
--- a/include/discord.inc
+++ b/include/discord.inc
@@ -134,6 +134,15 @@ methodmap DiscordMessage < Handle {
 	public native void GetChannelID(char[] buffer, int maxlength);
 };
 
+stock void Discord_EscapeString(char[] string, int maxlen)
+{
+	ReplaceString(string, maxlen, "@", "＠");
+	ReplaceString(string, maxlen, "'", "＇");
+	ReplaceString(string, maxlen, "\"", "＂");
+}
+
+native void Discord_SendMessage(const char[] webhook, const char[] message);
+
 #include <discord/channel>
 #include <discord/message_embed>
 #include <discord/webhook>


### PR DESCRIPTION
This fixes build issues with CallAdmin by @Zipcore and CallAdmin by @Impact123 and @dordnung
You can use all the plugins and dependencies with those two methods added to this include file.