### PR TITLE
Allow optional discord api usage

### DIFF
--- a/include/discord.inc
+++ b/include/discord.inc
@@ -139,3 +139,48 @@ methodmap DiscordMessage < Handle {
 #include <discord/webhook>
 #include <discord/bot>
 #include <discord/GuildMember>
+
+public SharedPlugin __pl_discordapi =
+{
+	name = "discord-api",
+	file = "discord-api.smx",
+	#if defined REQUIRE_PLUGIN
+	required = 1,
+	#else
+	required = 0,
+	#endif
+};
+
+#if !defined REQUIRE_PLUGIN
+public void __pl_discordapi_SetNTVOptional()
+{
+	MarkNativeAsOptional("DiscordUser.GetID");
+	MarkNativeAsOptional("DiscordUser.GetUsername");
+	MarkNativeAsOptional("DiscordUser.GetDiscriminator");
+	MarkNativeAsOptional("DiscordUser.GetAvatar");
+	MarkNativeAsOptional("DiscordUser.IsVerified");
+	MarkNativeAsOptional("DiscordUser.GetEmail");
+	MarkNativeAsOptional("DiscordUser.IsBot");
+	MarkNativeAsOptional("DiscordMessage.GetID");
+	MarkNativeAsOptional("DiscordMessage.IsPinned");
+	MarkNativeAsOptional("DiscordMessage.DiscordUser GetAuthor");
+	MarkNativeAsOptional("DiscordMessage.GetContent");
+	MarkNativeAsOptional("DiscordMessage.GetChannelID");
+	MarkNativeAsOptional("DiscordBot.StartTimer");
+	MarkNativeAsOptional("DiscordBot.AddReactionID");
+	MarkNativeAsOptional("DiscordBot.DeleteReactionID");
+	MarkNativeAsOptional("DiscordBot.GetReactionID");
+	MarkNativeAsOptional("DiscordBot.GetToken");
+	MarkNativeAsOptional("DiscordBot.SendMessage");
+	MarkNativeAsOptional("DiscordBot.SendMessageToChannelID");
+	MarkNativeAsOptional("DiscordBot.DeleteMessageID");
+	MarkNativeAsOptional("DiscordBot.DeleteMessage");
+	MarkNativeAsOptional("DiscordBot.GetGuilds");
+	MarkNativeAsOptional("DiscordBot.GetGuildChannels");
+	MarkNativeAsOptional("DiscordBot.GetGuildMembers");
+	MarkNativeAsOptional("DiscordBot.GetGuildMembersAll");
+	MarkNativeAsOptional("DiscordBot.GetGuildRoles");
+	MarkNativeAsOptional("DiscordChannel.SendMessage");
+	MarkNativeAsOptional("DiscordWebHook.Send");
+}
+#endif


### PR DESCRIPTION
This PR allows for optional Discord API usage, prior to this loading any plugin which includes this library would fail upon load if not present on a server.