### PR TITLE
Fixed webhook avatar not work

### DIFF
--- a/include/discord/webhook.inc
+++ b/include/discord/webhook.inc
@@ -96,11 +96,11 @@ methodmap DiscordWebHook < Handle {
 	}
 
 	public bool GetAvatar(char[] buffer, int maxlength) {
-		return this.GetDataString("icon_url", buffer, maxlength);
+		return this.GetDataString("avatar_url", buffer, maxlength);
 	}
 
 	public void SetAvatar(const char[] icon_url) {
-		this.UpdateDataObject("icon_url", json_string(icon_url));
+		this.UpdateDataObject("avatar_url", json_string(icon_url));
 	}
 
 	public bool GetContent(char[] buffer, int maxlength) {


### PR DESCRIPTION
Fixed changing avatar for webhook doesn't work.

I fixed it according to this link.
https://discord.com/developers/docs/resources/webhook#execute-webhook-jsonform-params